### PR TITLE
Improve integration with Fetch_Content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.16)
 
 project(MantidFortranRoutines)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 find_package (Python COMPONENTS Interpreter Development NumPy)
+find_package(PythonExtensions)
 
 # Find numpy headers
 exec_program(${Python_EXECUTABLE}

--- a/Fortran/Indirect/CMakeLists.txt
+++ b/Fortran/Indirect/CMakeLists.txt
@@ -1,22 +1,28 @@
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+
+set("3rdparty_libs_output_dir" ${PROJECT_BINARY_DIR}/bin)
+
+add_custom_target(build-time-make-directory ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${3rdparty_libs_output_dir})
 
 function(f2py_fortran_library module_name module_main only_arg) 
-set(generated_module_file ${CMAKE_CURRENT_BINARY_DIR}/${module_name}${PYTHON_EXTENSION_MODULE_SUFFIX})
+set(generated_module_file ${module_name}${PYTHON_EXTENSION_MODULE_SUFFIX})
 add_custom_target(${module_name} ALL
-  DEPENDS ${generated_module_file}
+  DEPENDS ${3rdparty_libs_output_dir}/${generated_module_file}
 )
+# windows commands
 if(WIN32)
 add_custom_command(
-  OUTPUT ${generated_module_file}
+  OUTPUT ${3rdparty_libs_output_dir}/${generated_module_file}
   COMMAND ${F2PY_EXECUTABLE} -c --fcompiler=gnu95 --compiler=mingw32 -m ${module_name} ${module_main} only: ${only_arg} : ${ARGN}
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  WORKING_DIRECTORY ${3rdparty_libs_output_dir}
 )
+# unix commands
 else()
 add_custom_command(
-  OUTPUT ${generated_module_file}
+  OUTPUT ${CMAKE_BINARY_DIR}/bin/${generated_module_file}
   COMMAND ${F2PY_EXECUTABLE} -c --fcompiler=gnu95 --compiler=unix -m ${module_name} ${module_main} only: ${only_arg} : ${ARGN}
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  WORKING_DIRECTORY ${3rdparty_libs_output_dir}
 )
 endif()
 endfunction()

--- a/Fortran/README.md
+++ b/Fortran/README.md
@@ -10,7 +10,7 @@ Using conda is the recommended way of building. On windows the following works:
 conda create --name fortran python=3.8
 conda activate fortran
 conda install numpy
-conda install -c msys2 m2w64-gcc-libgfortran
+conda install -c msys2 m2w64-gcc-fortran
 mkdir build
 cd build
 cmake ..

--- a/cmake/FindPythonExtensions.cmake
+++ b/cmake/FindPythonExtensions.cmake
@@ -1,0 +1,101 @@
+#.rst:
+#
+# This module defines CMake variables to build Python extension modules. 
+# Adapted from https://github.com/scikit-build/scikit-build/blob/master/skbuild/resources/cmake/FindPythonExtensions.cmake
+#
+
+#=============================================================================
+# Copyright 2011 Kitware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+find_package(PythonInterp REQUIRED)
+find_package(PythonLibs)
+
+set(_command "
+import distutils.sysconfig
+import itertools
+import os
+import os.path
+import site
+import sys
+
+result = None
+rel_result = None
+candidate_lists = []
+
+try:
+    candidate_lists.append((distutils.sysconfig.get_python_lib(),))
+except AttributeError: pass
+
+try:
+    candidate_lists.append(site.getsitepackages())
+except AttributeError: pass
+
+try:
+    candidate_lists.append((site.getusersitepackages(),))
+except AttributeError: pass
+
+candidates = itertools.chain.from_iterable(candidate_lists)
+
+for candidate in candidates:
+    rel_candidate = os.path.relpath(
+      candidate, sys.prefix)
+    if not rel_candidate.startswith(\"..\"):
+        result = candidate
+        rel_result = rel_candidate
+        break
+
+ext_suffix_var = 'SO'
+if sys.version_info[:2] >= (3, 5):
+    ext_suffix_var = 'EXT_SUFFIX'
+
+sys.stdout.write(\";\".join((
+    os.sep,
+    os.pathsep,
+    sys.prefix,
+    result,
+    rel_result,
+    distutils.sysconfig.get_config_var(ext_suffix_var)
+)))
+")
+
+execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "${_command}"
+                OUTPUT_VARIABLE _list
+                RESULT_VARIABLE _result)
+
+list(GET _list 0 _item)
+set(PYTHON_SEPARATOR "${_item}")
+mark_as_advanced(PYTHON_SEPARATOR)
+
+list(GET _list 1 _item)
+set(PYTHON_PATH_SEPARATOR "${_item}")
+mark_as_advanced(PYTHON_PATH_SEPARATOR)
+
+list(GET _list 2 _item)
+set(PYTHON_PREFIX "${_item}")
+mark_as_advanced(PYTHON_PREFIX)
+
+list(GET _list 3 _item)
+set(PYTHON_SITE_PACKAGES_DIR "${_item}")
+mark_as_advanced(PYTHON_SITE_PACKAGES_DIR)
+
+list(GET _list 4 _item)
+set(PYTHON_RELATIVE_SITE_PACKAGES_DIR "${_item}")
+mark_as_advanced(PYTHON_RELATIVE_SITE_PACKAGES_DIR)
+
+if(NOT DEFINED PYTHON_EXTENSION_MODULE_SUFFIX)
+  list(GET _list 5 _item)
+  set(PYTHON_EXTENSION_MODULE_SUFFIX "${_item}")
+endif()


### PR DESCRIPTION
This PR improves the integration with `FetchContent`. Once Conda is available In Mantid, this dependency can be added using:

```
include(FetchContent)
FetchContent_Declare(
  3rdpartysources
  GIT_REPOSITORY https://github.com/mantidproject/3rdpartysources
  GIT_TAG origin/master
)
FetchContent_MakeAvailable(3rdpartysources)
```
These changes mean the resulting libraries will be placed the `_depds/3rdpartysources-build/bin/` folder.
