### PR TITLE
Minor amendments to library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,16 @@ if(NUMPY_NOT_FOUND)
     message(FATAL_ERROR "NumPy headers not found")
 endif()
 
+
+# We have warnigns of converting COMPLEX to REALS, we need to silence them to build with later versions of gfrotran
+find_package(GFortran)
+set(GFORTRAN_FLAGS "")
+if (${GFORTRAN_VERSION_STRING} VERSION_LESS "10" )
+set(GFORTRAN_FLAGS "-Wno-argument-mismatch")
+else()
+set(GFORTRAN_FLAGS "-fallow-argument-mismatch")
+endif()
+
 find_package(F2PY REQUIRED)
 # include python and numpy dirs
 include_directories(${Python_INCLUDE_DIRS})

--- a/Fortran/Indirect/CMakeLists.txt
+++ b/Fortran/Indirect/CMakeLists.txt
@@ -14,14 +14,14 @@ add_custom_target(${module_name} ALL
 if(WIN32)
 add_custom_command(
   OUTPUT ${3rdparty_libs_output_dir}/${generated_module_file}
-  COMMAND ${F2PY_EXECUTABLE} -c --fcompiler=gnu95 --compiler=mingw32 -m ${module_name} ${module_main} only: ${only_arg} : ${ARGN}
+  COMMAND ${F2PY_EXECUTABLE} -c --fcompiler=gnu95 --compiler=mingw32 --opt=${GFORTRAN_FLAGS} -m ${module_name} ${module_main} only: ${only_arg} : ${ARGN}
   WORKING_DIRECTORY ${3rdparty_libs_output_dir}
 )
 # unix commands
 else()
 add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/bin/${generated_module_file}
-  COMMAND ${F2PY_EXECUTABLE} -c --fcompiler=gnu95 --compiler=unix -m ${module_name} ${module_main} only: ${only_arg} : ${ARGN}
+  OUTPUT ${3rdparty_libs_output_dir}/${generated_module_file}
+  COMMAND ${F2PY_EXECUTABLE} -c --fcompiler=gnu95 --compiler=unix --opt=${GFORTRAN_FLAGS} -m ${module_name} ${module_main} only: ${only_arg} : ${ARGN}
   WORKING_DIRECTORY ${3rdparty_libs_output_dir}
 )
 endif()

--- a/cmake/FindGFortran.cmake
+++ b/cmake/FindGFortran.cmake
@@ -1,0 +1,19 @@
+#.rst:
+#
+# Find the gfortran executable and its version
+
+find_program(GFORTRAN_EXECUTABLE NAMES gfortran)
+
+if(GFORTRAN_EXECUTABLE)
+execute_process(COMMAND "${GFORTRAN_EXECUTABLE}" -dumpversion
+OUTPUT_VARIABLE GFORTRAN_VERSION_STRING
+OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GFortran
+  REQUIRED_VARS GFORTRAN_EXECUTABLE
+  VERSION_VAR GFORTRAN_VERSION_STRING
+  )
+
+mark_as_advanced(GFORTRAN_EXECUTABLE GFORTRAN_VERSION_STRING)

--- a/cmake/FindPythonExtensions.cmake
+++ b/cmake/FindPythonExtensions.cmake
@@ -19,10 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-
-find_package(PythonInterp REQUIRED)
-find_package(PythonLibs)
-
 set(_command "
 import distutils.sysconfig
 import itertools
@@ -71,7 +67,8 @@ sys.stdout.write(\";\".join((
 )))
 ")
 
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "${_command}"
+if(Python_Interpreter_FOUND)
+execute_process(COMMAND "${Python_EXECUTABLE}" -c "${_command}"
                 OUTPUT_VARIABLE _list
                 RESULT_VARIABLE _result)
 
@@ -98,4 +95,8 @@ mark_as_advanced(PYTHON_RELATIVE_SITE_PACKAGES_DIR)
 if(NOT DEFINED PYTHON_EXTENSION_MODULE_SUFFIX)
   list(GET _list 5 _item)
   set(PYTHON_EXTENSION_MODULE_SUFFIX "${_item}")
+endif()
+
+else()
+message(STATUS "To define Python exetensions Python interpretator is required to be found.")
 endif()


### PR DESCRIPTION
Just a slight tweak to enable the f2py modules to be built with the latest version of gfortran, e.g. from homebrew. With gfortran > 10 the REAL TO COMPLEX conversion warnings become errors and therefore a flag needs to be supplied to the compiler. I've also added a small module to find gfortran and its version (as `enable_langague(Fortran)` doesn't work with mingw and windows with visual studio as the cmake generator). 

Lastly, I adjusted how the python extensions suffix is being found. It now requires that f`ind_package(Python COMPONENTS Interpreter...)` has been called prior to calling the module. This is consistent with how mantid finds python. With these changes I can now include this repo in mantid with the following:

```
include(FetchContent)
FetchContent_Declare(
  3rdpartysources
  GIT_REPOSITORY https://github.com/stephensmith25/3rdpartysources
  GIT_TAG        master
  GIT_SHALLOW    TRUE
)
FetchContent_MakeAvailable(3rdpartysources)
```
Which builds all the fortran python extensions in `build/_deps/3rdpartysources-build/bin`. This works on my windows and OSX machines. 